### PR TITLE
Fix broken logic with multiple sections

### DIFF
--- a/RFQuiltLayout/RFQuiltLayout.m
+++ b/RFQuiltLayout/RFQuiltLayout.m
@@ -176,7 +176,7 @@
     for (NSInteger section=self.lastIndexPathPlaced.section; section<numSections; section++) {
         NSInteger numRows = [self.collectionView numberOfItemsInSection:section];
         
-        for (NSInteger row = (!self.lastIndexPathPlaced? 0 : self.lastIndexPathPlaced.row + 1); row<numRows; row++) {
+        for (NSInteger row = (!(self.lastIndexPathPlaced && self.lastIndexPathPlaced.section == section) ? 0 : self.lastIndexPathPlaced.row + 1); row<numRows; row++) {
             NSIndexPath* indexPath = [NSIndexPath indexPathForRow:row inSection:section];
             
             if([self placeBlockAtIndex:indexPath]) {


### PR DESCRIPTION
There is an issue with the logic in `fillInBlocksToUnrestrictedRow:` when using collections views with multiple sections. The for loop for rows starts `row` at `self.lastIndexPathPlaced.row + 1`, this is incorrect if `section != self.lastIndexPathPlaced.section`, in which case, `row` should start at `0`.

To see a demonstration of the issue yourself, create a simple collection view with two sections, each with one item. You should see that only the item in the first section is created. This PR fixes that.